### PR TITLE
Use input for the variable name when updating a terraform config

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,8 +1,12 @@
 name: "Deploy Helm"
 description: "Deploys a new helm chart version to Smile's infrastructure."
 inputs:
-  chart_version:
-    description: "The new version of the helm chart that should be deployed."
+  variable_name:
+    description: "The name of Terraform variable to change in the service module."
+    required: false
+    default: "chart_version"
+  variable_value:
+    description: "The value of the corresponding 'variable_name'. This is usually the new version of the helm chart that should be deployed."
     required: true
   short_environment:
     description: "Environment short-form as used in Smile's infrastructure-live repo. One of `dev`, `stage`, `prod`"
@@ -20,8 +24,8 @@ runs:
       shell: bash
       run: |
         terraform-update-variable \
-          --name "chart_version" \
-          --value "\"${{ inputs.chart_version }}\"" \
+          --name "\${{ inputs.variable_name }}\"" \
+          --value "\"${{ inputs.variable_value }}\"" \
           --vars-path "${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}/terragrunt.hcl" \
           --git-url "https://github.com/smile-io/infrastructure-live.git" \
           --git-checkout-path "${{ runner.temp }}/infrastructure-live" \


### PR DESCRIPTION
While working on migrating `metabase` over to Github Actions, I noticed that it does not use the `chart_version` variable to deploy a new version. It instead uses `docker_image_tag` (as shown here https://github.com/smile-io/smile-metabase-docker/blob/master/.circleci/config.yml#L89).

Unfortunately, this means we need to make this action more flexible to accommodate this one-off. I couldn't think of a cleaner solution, so I welcome suggestions.