### PR TITLE
Update checkout action to V3

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Update infrastructure-live
       id: update_infra_live
       shell: bash


### PR DESCRIPTION
Updates the nested "checkout" action to V3 to fix a deprecation warning about Node 12.