### PR TITLE
feature: Add DataDog API event to track successful rollback

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -93,28 +93,28 @@ runs:
       shell: bash
       run: |
           echo "::error title=Error With Release::An unexpected error occured and Helm was unable to roll back successfully. Your changes may be partially deployed, and a manual rollback to a known working version via 'smile-cli app rollback' is recommended."
-        # Datadog API Event
-        # Define the event details
-        TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
-        TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}."
-        TAGS=("environment:${{ inputs.short_environment }}" "service:${{ inputs.helm_release_name }}" "action:failed_rollback")
-        JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
-        ALERT_TYPE="warning"
+          # Datadog API Event
+          # Define the event details
+          TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
+          TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}."
+          TAGS=("environment:${{ inputs.short_environment }}" "service:${{ inputs.helm_release_name }}" "action:failed_rollback")
+          JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
+          ALERT_TYPE="warning"
 
-        # Use curl to send the event to Datadog
-        RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.datadoghq.com/api/v1/events" \
-             -H "Content-Type: application/json" \
-             -H "DD-API-KEY: ${DD_API_KEY}" \
-             -d "{
-                 \"title\": \"${TITLE}\",
-                 \"text\": \"${TEXT}\",
-                 \"tags\": ${JSON_TAGS},
-                 \"alert_type\": \"$ALERT_TYPE\"
-             }")
+          # Use curl to send the event to Datadog
+          RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.datadoghq.com/api/v1/events" \
+               -H "Content-Type: application/json" \
+               -H "DD-API-KEY: ${DD_API_KEY}" \
+               -d "{
+                   \"title\": \"${TITLE}\",
+                   \"text\": \"${TEXT}\",
+                   \"tags\": ${JSON_TAGS},
+                   \"alert_type\": \"$ALERT_TYPE\"
+               }")
 
-        if [ "$RESPONSE" -ne 202 ]; then
-            echo "Failed to send event to Datadog. API responded with status code: $RESPONSE"
-            exit 1
-        else
-            echo "Event sent to Datadog successfully."
-        fi
+          if [ "$RESPONSE" -ne 202 ]; then
+              echo "Failed to send event to Datadog. API responded with status code: $RESPONSE"
+              exit 1
+          else
+              echo "Event sent to Datadog successfully."
+          fi

--- a/action.yaml
+++ b/action.yaml
@@ -81,7 +81,7 @@ runs:
           -d "{
             \"title\": \"${TITLE}\",
             \"text\": \"${TEXT}\",
-            \"tags\": [\"environment:${inputs.short_environment}\",\"service:${inputs.helm_release_name}\",\"action:rollback\"]
+            \"tags\": [\"${TAGS}\"],
             \"alert_type\": \"$ALERT_TYPE\"
           }"
     - name: Handle Failed Rollback

--- a/action.yaml
+++ b/action.yaml
@@ -59,6 +59,7 @@ runs:
           --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
           --output text))
         aws eks update-kubeconfig --name eks-${{ inputs.short_environment }} --region us-east-1
+        echo "Command: helm history ${{ inputs.helm_release_name }} --max 1 -n applications -o json | jq -r .[0].status)"
         echo "release_status=$(helm history ${{ inputs.helm_release_name }} --max 1 -n applications -o json | jq -r .[0].status)" >> $GITHUB_OUTPUT
     - name: Handle Successful Rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' && steps.detect_rollback_success.outputs.release_status == 'deployed' }}

--- a/action.yaml
+++ b/action.yaml
@@ -69,15 +69,14 @@ runs:
         # Define the event details
         TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
         TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
-        TAGS="environment:${{ inputs.short_environment }},service:${{ inputs.helm_release_name }},action:rollback"
-        JSON_TAGS="[\"$(echo $TAGS | tr ',' '","' | tr ':' '\":\"')\"]"
+        TAGS=("environment:${{ inputs.short_environment }}" "service:${{ inputs.helm_release_name }}" "action:rollback")
+        JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
         ALERT_TYPE="warning"
 
         # Use curl to send the event to Datadog
         RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.datadoghq.com/api/v1/events" \
              -H "Content-Type: application/json" \
-             -H "DD-API-KEY: ${API_KEY}" \
-             -H "DD-APPLICATION-KEY: ${APP_KEY}" \
+             -H "DD-API-KEY: ${DD_API_KEY}" \
              -d "{
                  \"title\": \"${TITLE}\",
                  \"text\": \"${TEXT}\",

--- a/action.yaml
+++ b/action.yaml
@@ -69,7 +69,7 @@ runs:
         # Define the event details
         TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
         TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
-        TAGS="environment:${{ inputs.short_environment }},service:${{ inputs.helm_release_name }},action:rollback"
+        TAGS="environment:${{ inputs.short_environment }}, service:${{ inputs.helm_release_name }}, action:rollback"
         ALERT_TYPE="warning"
 
         # Use curl to send the event to Datadog

--- a/action.yaml
+++ b/action.yaml
@@ -58,16 +58,6 @@ runs:
           --output text))
         aws eks update-kubeconfig --name eks-${{ inputs.short_environment }} --region us-east-1
         echo "release_status=$(helm history ${{ inputs.helm_release_name }} --max 1 -n applications -o json | jq -r .[0].status)" >> $GITHUB_OUTPUT
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v2
-      with:
-        role-to-assume: arn:aws:iam::${{ fromJson(inputs.env_to_account_mapping_json)[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts
-        aws-region: us-east-1
-    - name: Get secrets by ARN
-      uses: aws-actions/aws-secretsmanager-get-secrets@v1
-      with:
-        secret-ids: |
-          DATADOG_API_KEY,arn:aws:secretsmanager:us-east-1:877068819435:secret:datadog_api_key20210504192721241900000001-PyKNpM
     - name: Handle Successful Rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' && steps.detect_rollback_success.outputs.release_status == 'deployed' }}
       shell: bash
@@ -83,7 +73,7 @@ runs:
         # Use curl to send the event to Datadog
         curl -X POST "https://api.datadoghq.com/api/v1/events" \
           -H "Content-type: application/json" \
-          -H "DD-API-KEY: ${{ DATADOG_API_KEY }}" \
+          -H "DD-API-KEY: $DD_API_KEY" \
           -d '{
             "title": "'"$TITLE"'",
             "text": "'"$TEXT"'",

--- a/action.yaml
+++ b/action.yaml
@@ -63,6 +63,23 @@ runs:
       shell: bash
       run: |
         echo "::error title=Error With Release::Your release failed to apply to Smile's Kubernetes cluster successfully. This means one or more services were unable to start up properly, check your application logs in DataDog for errors or reach out to the SRE team for help debugging. If you can't find anything and think this may be a transient issue, you can try deploying again by retrying this Github Action."
+        # Datadog API Event
+        # Define the event details
+        TITLE="Deployment Rollback"
+        TEXT="A rollback occurred in ${{ inputs.short_environment }}."
+        TAGS="environment:${{ inputs.short_environment }},action:rollback"
+        ALERT_TYPE="warning"
+
+        # Use curl to send the event to Datadog
+        curl -X POST "https://api.datadoghq.com/api/v1/events" \
+          -H "Content-type: application/json" \
+          -H "DD-API-KEY: ${{ secrets.DATADOG_API_KEY }}" \
+          -d '{
+            "title": "'"$TITLE"'",
+            "text": "'"$TEXT"'",
+            "tags": ["'"$TAGS"'"],
+            "alert_type": "'"$ALERT_TYPE"'"
+          }'
     - name: Handle Failed Rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' && steps.detect_rollback_success.outputs.release_status != 'deployed' }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -45,8 +45,6 @@ runs:
       shell: bash
       run: |
         terragrunt apply --terragrunt-working-dir "${{ runner.temp }}/infrastructure-live/${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}"  --terragrunt-iam-role "arn:aws:iam::${{ fromJson(inputs.env_to_account_mapping_json)[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts" -input=false -auto-approve
-        # Force failure
-        exit 1
     - name: Detect successful rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' }}
       id: detect_rollback_success
@@ -95,3 +93,28 @@ runs:
       shell: bash
       run: |
           echo "::error title=Error With Release::An unexpected error occured and Helm was unable to roll back successfully. Your changes may be partially deployed, and a manual rollback to a known working version via 'smile-cli app rollback' is recommended."
+        # Datadog API Event
+        # Define the event details
+        TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
+        TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}."
+        TAGS=("environment:${{ inputs.short_environment }}" "service:${{ inputs.helm_release_name }}" "action:rollback")
+        JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
+        ALERT_TYPE="error"
+
+        # Use curl to send the event to Datadog
+        RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.datadoghq.com/api/v1/events" \
+             -H "Content-Type: application/json" \
+             -H "DD-API-KEY: ${DD_API_KEY}" \
+             -d "{
+                 \"title\": \"${TITLE}\",
+                 \"text\": \"${TEXT}\",
+                 \"tags\": ${JSON_TAGS},
+                 \"alert_type\": \"$ALERT_TYPE\"
+             }")
+
+        if [ "$RESPONSE" -ne 202 ]; then
+            echo "Failed to send event to Datadog. API responded with status code: $RESPONSE"
+            exit 1
+        else
+            echo "Event sent to Datadog successfully."
+        fi

--- a/action.yaml
+++ b/action.yaml
@@ -97,7 +97,7 @@ runs:
         # Define the event details
         TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
         TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}."
-        TAGS=("environment:${{ inputs.short_environment }}" "service:${{ inputs.helm_release_name }}" "action:rollback")
+        TAGS=("environment:${{ inputs.short_environment }}" "service:${{ inputs.helm_release_name }}" "action:failed_rollback")
         JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
         ALERT_TYPE="error"
 

--- a/action.yaml
+++ b/action.yaml
@@ -58,6 +58,16 @@ runs:
           --output text))
         aws eks update-kubeconfig --name eks-${{ inputs.short_environment }} --region us-east-1
         echo "release_status=$(helm history ${{ inputs.helm_release_name }} --max 1 -n applications -o json | jq -r .[0].status)" >> $GITHUB_OUTPUT
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: arn:aws:iam::${{ fromJson(inputs.env_to_account_mapping_json)[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts
+        aws-region: us-east-1
+    - name: Get secrets by ARN
+      uses: aws-actions/aws-secretsmanager-get-secrets@v1
+      with:
+        secret-ids: |
+          DATADOG_API_KEY,arn:aws:secretsmanager:us-east-1:877068819435:secret:datadog_api_key20210504192721241900000001-PyKNpM
     - name: Handle Successful Rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' && steps.detect_rollback_success.outputs.release_status == 'deployed' }}
       shell: bash
@@ -73,7 +83,7 @@ runs:
         # Use curl to send the event to Datadog
         curl -X POST "https://api.datadoghq.com/api/v1/events" \
           -H "Content-type: application/json" \
-          -H "DD-API-KEY: ${{ secrets.DATADOG_API_KEY }}" \
+          -H "DD-API-KEY: ${{ DATADOG_API_KEY }}" \
           -d '{
             "title": "'"$TITLE"'",
             "text": "'"$TEXT"'",

--- a/action.yaml
+++ b/action.yaml
@@ -70,6 +70,8 @@ runs:
         TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
         TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
         TAGS="environment:${{ inputs.short_environment }},service:${{ inputs.helm_release_name }},action:rollback"
+        ENVIRONMENT="$inputs.short_environment}"
+        SERVICE="$inputs.helm_release_name"
         ALERT_TYPE="warning"
 
         # Use curl to send the event to Datadog
@@ -79,7 +81,7 @@ runs:
           -d "{
             \"title\": \"${TITLE}\",
             \"text\": \"${TEXT}\",
-            \"tags\": [\"environment:${{ inputs.short_environment }}\",\"service:${{ inputs.helm_release_name }}\",\"action:rollback\"]
+            \"tags\": [\"environment:${inputs.short_environment}\",\"service:${inputs.helm_release_name}\",\"action:rollback\"]
             \"alert_type\": \"$ALERT_TYPE\"
           }"
     - name: Handle Failed Rollback

--- a/action.yaml
+++ b/action.yaml
@@ -79,7 +79,7 @@ runs:
           -d "{
             \"title\": \"${TITLE}\",
             \"text\": \"${TEXT}\",
-            \"tags\": [\"{$TAGS}\", \"custom:metric\"],
+            \"tags\": [\"environment:${{ inputs.short_environment }}\",\"service:${{ inputs.helm_release_name }}\",\"action:rollback\"]
             \"alert_type\": \"$ALERT_TYPE\"
           }"
     - name: Handle Failed Rollback

--- a/action.yaml
+++ b/action.yaml
@@ -99,7 +99,7 @@ runs:
         TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}."
         TAGS=("environment:${{ inputs.short_environment }}" "service:${{ inputs.helm_release_name }}" "action:failed_rollback")
         JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
-        ALERT_TYPE="error"
+        ALERT_TYPE="warning"
 
         # Use curl to send the event to Datadog
         RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.datadoghq.com/api/v1/events" \

--- a/action.yaml
+++ b/action.yaml
@@ -70,9 +70,9 @@ runs:
         TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
         TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
         TAGS="environment:${{ inputs.short_environment }},service:${{ inputs.helm_release_name }},action:rollback"
-        ENVIRONMENT="$inputs.short_environment}"
-        SERVICE="$inputs.helm_release_name"
+        JSON_TAGS="[\"$(echo $TAGS | tr ',' '","' | tr ':' '\":\"')\"]"
         ALERT_TYPE="warning"
+
 
         # Use curl to send the event to Datadog
         curl -X POST "https://api.datadoghq.com/api/v1/events" \
@@ -81,7 +81,7 @@ runs:
           -d "{
             \"title\": \"${TITLE}\",
             \"text\": \"${TEXT}\",
-            \"tags\": [\"${TAGS}\"],
+            \"tags\": ${JSON_TAGS},
             \"alert_type\": \"$ALERT_TYPE\"
           }"
     - name: Handle Failed Rollback

--- a/action.yaml
+++ b/action.yaml
@@ -79,7 +79,7 @@ runs:
           -d "{
             \"title\": \"${TITLE}\",
             \"text\": \"${TEXT}\",
-            \"tags\": ["{$TAGS}"],
+            \"tags\": [\"{$TAGS}\", \"custom:metric\"],
             \"alert_type\": \"$ALERT_TYPE\"
           }"
     - name: Handle Failed Rollback

--- a/action.yaml
+++ b/action.yaml
@@ -73,6 +73,7 @@ runs:
         JSON_TAGS="[\"$(echo $TAGS | tr ',' '","' | tr ':' '\":\"')\"]"
         ALERT_TYPE="warning"
 
+        echo ">>TAGS:  ${JSON_TAGS}"
 
         # Use curl to send the event to Datadog
         curl -X POST "https://api.datadoghq.com/api/v1/events" \

--- a/action.yaml
+++ b/action.yaml
@@ -69,19 +69,19 @@ runs:
         # Define the event details
         TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
         TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
-        TAGS="environment:${{ inputs.short_environment }}, service:${{ inputs.helm_release_name }}, action:rollback"
+        TAGS="environment:${{ inputs.short_environment }},service:${{ inputs.helm_release_name }},action:rollback"
         ALERT_TYPE="warning"
 
         # Use curl to send the event to Datadog
         curl -X POST "https://api.datadoghq.com/api/v1/events" \
           -H "Content-type: application/json" \
           -H "DD-API-KEY: $DD_API_KEY" \
-          -d '{
-            "title": "'"$TITLE"'",
-            "text": "'"$TEXT"'",
-            "tags": ["'"$TAGS"'"],
-            "alert_type": "'"$ALERT_TYPE"'"
-          }'
+          -d "{
+            \"title\": \"${TITLE}\",
+            \"text\": \"${TEXT}\",
+            \"tags\": ["{$TAGS}"],
+            \"alert_type\": \"$ALERT_TYPE\"
+          }"
     - name: Handle Failed Rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' && steps.detect_rollback_success.outputs.release_status != 'deployed' }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -73,18 +73,24 @@ runs:
         JSON_TAGS="[\"$(echo $TAGS | tr ',' '","' | tr ':' '\":\"')\"]"
         ALERT_TYPE="warning"
 
-        echo ">>TAGS:  ${JSON_TAGS}"
-
         # Use curl to send the event to Datadog
-        curl -X POST "https://api.datadoghq.com/api/v1/events" \
-          -H "Content-type: application/json" \
-          -H "DD-API-KEY: $DD_API_KEY" \
-          -d "{
-            \"title\": \"${TITLE}\",
-            \"text\": \"${TEXT}\",
-            \"tags\": ${JSON_TAGS},
-            \"alert_type\": \"$ALERT_TYPE\"
-          }"
+        RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "https://api.datadoghq.com/api/v1/events" \
+             -H "Content-Type: application/json" \
+             -H "DD-API-KEY: ${API_KEY}" \
+             -H "DD-APPLICATION-KEY: ${APP_KEY}" \
+             -d "{
+                 \"title\": \"${TITLE}\",
+                 \"text\": \"${TEXT}\",
+                 \"tags\": ${JSON_TAGS},
+                 \"alert_type\": \"$ALERT_TYPE\"
+             }")
+
+        if [ "$RESPONSE" -ne 202 ]; then
+            echo "Failed to send event to Datadog. API responded with status code: $RESPONSE"
+            exit 1
+        else
+            echo "Event sent to Datadog successfully."
+        fi
     - name: Handle Failed Rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' && steps.detect_rollback_success.outputs.release_status != 'deployed' }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -67,9 +67,9 @@ runs:
         echo "::error title=Error With Release::Your release failed to apply to Smile's Kubernetes cluster successfully. This means one or more services were unable to start up properly, check your application logs in DataDog for errors or reach out to the SRE team for help debugging. If you can't find anything and think this may be a transient issue, you can try deploying again by retrying this Github Action."
         # Datadog API Event
         # Define the event details
-        TITLE="${{ inputs.short_environment }}/${{ inputs.helm_release_name }} deployment rollback"
+        TITLE="[${{ inputs.short_environment }}] ${{ inputs.helm_release_name }} deployment rollback"
         TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
-        TAGS="environment:${{ inputs.short_environment }},app:action:rollback"
+        TAGS="environment:${{ inputs.short_environment }},service:${{ inputs.helm_release_name }},action:rollback"
         ALERT_TYPE="warning"
 
         # Use curl to send the event to Datadog

--- a/action.yaml
+++ b/action.yaml
@@ -45,6 +45,8 @@ runs:
       shell: bash
       run: |
         terragrunt apply --terragrunt-working-dir "${{ runner.temp }}/infrastructure-live/${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}"  --terragrunt-iam-role "arn:aws:iam::${{ fromJson(inputs.env_to_account_mapping_json)[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts" -input=false -auto-approve
+        # Force failure
+        exit 1
     - name: Detect successful rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' }}
       id: detect_rollback_success

--- a/action.yaml
+++ b/action.yaml
@@ -59,7 +59,6 @@ runs:
           --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
           --output text))
         aws eks update-kubeconfig --name eks-${{ inputs.short_environment }} --region us-east-1
-        echo "Command: helm history ${{ inputs.helm_release_name }} --max 1 -n applications -o json | jq -r .[0].status)"
         echo "release_status=$(helm history ${{ inputs.helm_release_name }} --max 1 -n applications -o json | jq -r .[0].status)" >> $GITHUB_OUTPUT
     - name: Handle Successful Rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' && steps.detect_rollback_success.outputs.release_status == 'deployed' }}
@@ -68,9 +67,9 @@ runs:
         echo "::error title=Error With Release::Your release failed to apply to Smile's Kubernetes cluster successfully. This means one or more services were unable to start up properly, check your application logs in DataDog for errors or reach out to the SRE team for help debugging. If you can't find anything and think this may be a transient issue, you can try deploying again by retrying this Github Action."
         # Datadog API Event
         # Define the event details
-        TITLE="Deployment Rollback"
-        TEXT="A rollback occurred in ${{ inputs.short_environment }}."
-        TAGS="environment:${{ inputs.short_environment }},action:rollback"
+        TITLE="${{ inputs.short_environment }}/${{ inputs.helm_release_name }} deployment rollback"
+        TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
+        TAGS="environment:${{ inputs.short_environment }},app:action:rollback"
         ALERT_TYPE="warning"
 
         # Use curl to send the event to Datadog


### PR DESCRIPTION
This PR adds a DataDog event for tracking successful and failed rollbacks via our CD pipeline when Terraform fails to apply the releases.