### PR TITLE
Feature/add gh action url in datadog event

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -39,6 +39,7 @@ runs:
           --git-user-name "smile-ci-service" \
           --github-token-secrets-manager-arn "arn:aws:secretsmanager:us-east-1:877068819435:secret:smile-ci-service-github-token-mKMOOR" \
           --ssh-key-secrets-manager-arn "arn:aws:secretsmanager:us-east-1:877068819435:secret:smile-ci-service-github-ssh-private-key-osnOEZ"
+          exit 1
     - name: Handle Release Errors
       if: ${{ failure() && steps.update_infra_live.conclusion == 'failure' }}
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -39,7 +39,6 @@ runs:
           --git-user-name "smile-ci-service" \
           --github-token-secrets-manager-arn "arn:aws:secretsmanager:us-east-1:877068819435:secret:smile-ci-service-github-token-mKMOOR" \
           --ssh-key-secrets-manager-arn "arn:aws:secretsmanager:us-east-1:877068819435:secret:smile-ci-service-github-ssh-private-key-osnOEZ"
-          exit 1
     - name: Handle Release Errors
       if: ${{ failure() && steps.update_infra_live.conclusion == 'failure' }}
       shell: bash
@@ -49,6 +48,7 @@ runs:
       shell: bash
       run: |
         terragrunt apply --terragrunt-working-dir "${{ runner.temp }}/infrastructure-live/${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}"  --terragrunt-iam-role "arn:aws:iam::${{ fromJson(inputs.env_to_account_mapping_json)[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts" -input=false -auto-approve
+        exit 1
     - name: Detect successful rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' }}
       id: detect_rollback_success

--- a/action.yaml
+++ b/action.yaml
@@ -48,7 +48,6 @@ runs:
       shell: bash
       run: |
         terragrunt apply --terragrunt-working-dir "${{ runner.temp }}/infrastructure-live/${{ inputs.short_environment }}/us-east-1/${{ inputs.short_environment }}/services/${{ inputs.terraform_module_name }}"  --terragrunt-iam-role "arn:aws:iam::${{ fromJson(inputs.env_to_account_mapping_json)[inputs.short_environment] }}:role/allow-auto-deploy-from-other-accounts" -input=false -auto-approve
-        exit 1
     - name: Detect successful rollback
       if: ${{ failure() && steps.release_changes.conclusion == 'failure' }}
       id: detect_rollback_success

--- a/action.yaml
+++ b/action.yaml
@@ -70,7 +70,7 @@ runs:
         # Datadog API Event
         # Define the event details
         TITLE="[${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}] ${{ inputs.helm_release_name }} deployment rollback"
-        TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}. Check GitHub Action details here https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        TEXT="%%% \n${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}.\n\nCheck GitHub Action details [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         TAGS=("environment:${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}" "service:${{ inputs.helm_release_name }}" "action:rollback")
         JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
         ALERT_TYPE="warning"
@@ -99,9 +99,8 @@ runs:
           echo "::error title=Error With Release::An unexpected error occured and Helm was unable to roll back successfully. Your changes may be partially deployed, and a manual rollback to a known working version via 'smile-cli app rollback' is recommended."
           # Datadog API Event
           # Define the event details
-          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           TITLE="[${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}] ${{ inputs.helm_release_name }} deployment rollback"
-          TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}. Check GitHub Action details here https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TEXT="%%% \n${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}.\n\nCheck GitHub Action details [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})"
           TAGS=("environment:${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}" "service:${{ inputs.helm_release_name }}" "action:failed_rollback")
           JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
           ALERT_TYPE="warning"

--- a/action.yaml
+++ b/action.yaml
@@ -69,7 +69,7 @@ runs:
         # Datadog API Event
         # Define the event details
         TITLE="[${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}] ${{ inputs.helm_release_name }} deployment rollback"
-        TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}."
+        TEXT="${{ inputs.helm_release_name }} app was rolled back in ${{ inputs.short_environment }}. Check GitHub Action details here https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         TAGS=("environment:${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}" "service:${{ inputs.helm_release_name }}" "action:rollback")
         JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
         ALERT_TYPE="warning"
@@ -98,8 +98,9 @@ runs:
           echo "::error title=Error With Release::An unexpected error occured and Helm was unable to roll back successfully. Your changes may be partially deployed, and a manual rollback to a known working version via 'smile-cli app rollback' is recommended."
           # Datadog API Event
           # Define the event details
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           TITLE="[${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}] ${{ inputs.helm_release_name }} deployment rollback"
-          TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}."
+          TEXT="${{ inputs.helm_release_name }} app rollback failed in ${{ inputs.short_environment }}. Check GitHub Action details here https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           TAGS=("environment:${{ fromJson(inputs.environment_mapping_json)[inputs.short_environment] }}" "service:${{ inputs.helm_release_name }}" "action:failed_rollback")
           JSON_TAGS=$(printf '%s\n' "${TAGS[@]}" | jq -R . | jq -s .)
           ALERT_TYPE="warning"


### PR DESCRIPTION
This PR add the link to the failed GitHub Action in the DataDog event message